### PR TITLE
fix: make `routing.localhost` listen on `*` as well

### DIFF
--- a/system/nginx.nix
+++ b/system/nginx.nix
@@ -14,9 +14,10 @@
                     proxyPass = "http://localhost:${builtins.toString config.services.stregsystemet.port}/";
                 };
             };
-            # it will only run on localhost, its for debugging
+            # it will only run on localhost, its for debugging. Listens on "*" to
+            # be accessible outside of VM
             "routing.localhost" = {
-                listen = [{ addr = "localhost"; }];
+                listen = [{ addr = "localhost"; } { addr = "*"; }];
                 locations."/".index = "${pkgs.writeText "index.html" ''
                     <div style="text-align: center;">
                         <h3>F-Klubben | Routing</h3>


### PR DESCRIPTION
When trying to access from outside the virtual machine, it connects from an address other than `localhost`, so exclusively listening to `localhost` will not work. Listening to `*` is fine, since `.localhost` domains always refer to `localhost` anyway. Worst case is that someone spoofs a request, and there's nothing special they can achieve with that.