### PR TITLE
feat: use a slightly different config for testing and production

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -9,9 +9,23 @@
         system = "x86_64-linux";
         pkgs = nixpkgs.legacyPackages.${system};
     in {
-        nixosConfigurations.fklub = nixpkgs.lib.nixosSystem {
+        nixosConfigurations.fklub-test = nixpkgs.lib.nixosSystem {
             inherit system;
-            modules = [ ./system/configuration.nix ];
+            modules = [
+                ./system/configuration.nix
+                {
+                    fklub.domain = "localhost";
+                }
+            ];
+        };
+        nixosConfigurations.fklub-prod = nixpkgs.lib.nixosSystem {
+            inherit system;
+            modules = [
+                ./system/configuration.nix
+                {
+                    fklub.domain = "fklub.dk";
+                }
+            ];
         };
     };
 }

--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,5 @@
 set -e
 
 cd $(dirname $0)
-nixos-rebuild build-vm --flake .#fklub
+nixos-rebuild build-vm --flake .#fklub-test
 result/bin/run-fklub-vm

--- a/system/configuration.nix
+++ b/system/configuration.nix
@@ -39,5 +39,4 @@
 
     # #FRITFIT (custom shiz)
     services.stregsystemet.enable = true;
-    fklub.domain = "fklub.dk";
 }


### PR DESCRIPTION
This is useful for things where we need to have a slightly different configuration for testing locally. Currently it's primarily for the domain name, but it will likely also prove useful for things like Stregsystemet, where we want to use test data locally and then real data in production.