### PR TITLE
ci: enable Nix caching

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,8 @@ jobs:
         steps:
             - uses: actions/checkout@v4.1.1
 
-            - uses: cachix/install-nix-action@v25
+            - uses: nixbuild/nix-quick-install-action@v27
+            - uses: nix-community/cache-nix-action@v5
 
             - name: build-stregsystemet
               run: nix build .#stregsystemet

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,10 @@ jobs:
             - uses: actions/checkout@v4.1.1
 
             - uses: nixbuild/nix-quick-install-action@v27
+
             - uses: nix-community/cache-nix-action@v5
+              with:
+                primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix') }}
 
             - name: build-stregsystemet
               run: nix build .#stregsystemet


### PR DESCRIPTION
This will make CI runs go faster when some things don't need to be rebuilt. I replaced `cachix/install-nix-action` with `nixbuild/nix-quick-install-action`, since it's required by `nix-community/cache-nix-action`.

~~Do not merge yet, it still needs to be tested.~~ Ready pending approval.