### PR TITLE
refactor: avoid dependency on Nix channels

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: NixOS Package Building
 on:
     push:
         branches: [ main ]
-    pull_request: 
+    pull_request:
         branches: [ main ]
 
 jobs:
@@ -13,8 +13,6 @@ jobs:
             - uses: actions/checkout@v4.1.1
 
             - uses: cachix/install-nix-action@v25
-              with:
-                nix_path: nixpkgs=channel:nixos-23.11
 
             - name: build-stregsystemet
-              run: nix build -f ./pkgs/stregsystemet
+              run: nix build .#stregsystemet

--- a/flake.nix
+++ b/flake.nix
@@ -27,5 +27,7 @@
                 }
             ];
         };
+
+        packages."${system}".stregsystemet = pkgs.callPackage ./pkgs/stregsystemet {};
     };
 }

--- a/pkgs/stregsystemet/default.nix
+++ b/pkgs/stregsystemet/default.nix
@@ -1,4 +1,4 @@
-{pkgs ? import <nixpkgs> {}}:
+{pkgs}:
 let
     env = pkgs.python3.withPackages (py: with py; [
         pillow
@@ -16,14 +16,14 @@ let
 in pkgs.stdenv.mkDerivation {
 	pname = "stregsystemet";
     name = "stregsystemet";
-	
+
 	src = pkgs.fetchFromGitHub {
 		owner = "f-klubben";
 		repo = "stregsystemet";
 		rev = "af0efd806ae743b0e8a9639376c4a31b81d61cd2";
 		sha256 = "sha256-0IwvGMyVd91h7bECTEqL2XydVewJZC+soctLnzTFASo=";
 	};
-	
+
 	installPhase = ''
 		mkdir -p $out/bin
 		mkdir -p $out/share/stregsystemet

--- a/pkgs/stregsystemet/dependencies/certifi.nix
+++ b/pkgs/stregsystemet/dependencies/certifi.nix
@@ -1,4 +1,4 @@
-{pkgs ? import <nixpkgs> {}}:
+{pkgs}:
 
 pkgs.python3Packages.buildPythonPackage {
     pname = "certifi";

--- a/pkgs/stregsystemet/dependencies/chardet.nix
+++ b/pkgs/stregsystemet/dependencies/chardet.nix
@@ -1,4 +1,4 @@
-{pkgs ? import <nixpkgs> {}}:
+{pkgs}:
 
 pkgs.python3Packages.buildPythonPackage {
     pname = "chardet";

--- a/pkgs/stregsystemet/dependencies/coverage.nix
+++ b/pkgs/stregsystemet/dependencies/coverage.nix
@@ -1,4 +1,4 @@
-{pkgs ? import <nixpkgs> {}}: 
+{pkgs}:
 
 pkgs.python3Packages.buildPythonPackage {
     pname = "Coverage";
@@ -13,5 +13,5 @@ pkgs.python3Packages.buildPythonPackage {
     checkInputs = [];
     nativeBuildInputs = [];
     propagatedBuildInputs = [];
-  
+
 }

--- a/pkgs/stregsystemet/dependencies/django-appconf.nix
+++ b/pkgs/stregsystemet/dependencies/django-appconf.nix
@@ -1,4 +1,4 @@
-{pkgs ? import <nixpkgs> {}}:
+{pkgs}:
 
 pkgs.python3Packages.buildPythonPackage {
     pname = "django-appconf";

--- a/pkgs/stregsystemet/dependencies/django-debug-toolbar.nix
+++ b/pkgs/stregsystemet/dependencies/django-debug-toolbar.nix
@@ -1,4 +1,4 @@
-{pkgs ? import <nixpkgs> {}}:
+{pkgs}:
 
 pkgs.python3Packages.buildPythonPackage {
     pname = "django-debug-toolbar";

--- a/pkgs/stregsystemet/dependencies/django-select2.nix
+++ b/pkgs/stregsystemet/dependencies/django-select2.nix
@@ -1,4 +1,4 @@
-{pkgs ? import <nixpkgs> {}}:
+{pkgs}:
 
 pkgs.python3Packages.buildPythonPackage {
     pname = "Django-Select2";

--- a/pkgs/stregsystemet/dependencies/django.nix
+++ b/pkgs/stregsystemet/dependencies/django.nix
@@ -1,4 +1,4 @@
-{pkgs ? import <nixpkgs> {}}:
+{pkgs}:
 
 pkgs.python3Packages.buildPythonPackage {
     pname = "Django";

--- a/pkgs/stregsystemet/dependencies/freezegun.nix
+++ b/pkgs/stregsystemet/dependencies/freezegun.nix
@@ -1,4 +1,4 @@
-{pkgs ? import <nixpkgs> {}}:
+{pkgs}:
 
 pkgs.python3Packages.buildPythonPackage {
     pname = "freezegun";

--- a/pkgs/stregsystemet/dependencies/idna.nix
+++ b/pkgs/stregsystemet/dependencies/idna.nix
@@ -1,4 +1,4 @@
-{pkgs ? import <nixpkgs> {}}:
+{pkgs}:
 
 pkgs.python3Packages.buildPythonPackage {
     pname = "idna";

--- a/pkgs/stregsystemet/dependencies/pillow.nix
+++ b/pkgs/stregsystemet/dependencies/pillow.nix
@@ -1,4 +1,4 @@
-{pkgs ? import <nixpkgs> {}}:
+{pkgs}:
 
 pkgs.python3Packages.buildPythonPackage {
     pname = "Pillow";

--- a/pkgs/stregsystemet/dependencies/python-dateutil.nix
+++ b/pkgs/stregsystemet/dependencies/python-dateutil.nix
@@ -1,4 +1,4 @@
-{pkgs ? import <nixpkgs> {}}:
+{pkgs}:
 
 pkgs.python3Packages.buildPythonPackage {
     pname = "python-dateutil";

--- a/pkgs/stregsystemet/dependencies/pytz.nix
+++ b/pkgs/stregsystemet/dependencies/pytz.nix
@@ -1,4 +1,4 @@
-{pkgs ? import <nixpkgs> {}}:
+{pkgs}:
 
 pkgs.python3Packages.buildPythonPackage {
     pname = "pytz";

--- a/pkgs/stregsystemet/dependencies/qrcode.nix
+++ b/pkgs/stregsystemet/dependencies/qrcode.nix
@@ -1,4 +1,4 @@
-{pkgs ? import <nixpkgs> {}}:
+{pkgs}:
 
 pkgs.python3Packages.buildPythonPackage {
     pname = "qrcode";

--- a/pkgs/stregsystemet/dependencies/regex.nix
+++ b/pkgs/stregsystemet/dependencies/regex.nix
@@ -1,4 +1,4 @@
-{pkgs ? import <nixpkgs> {}}:
+{pkgs}:
 
 pkgs.python3Packages.buildPythonPackage {
     pname = "regex";

--- a/pkgs/stregsystemet/dependencies/requests.nix
+++ b/pkgs/stregsystemet/dependencies/requests.nix
@@ -1,4 +1,4 @@
-{pkgs ? import <nixpkgs> {}}:
+{pkgs}:
 
 pkgs.python3Packages.buildPythonPackage {
     pname = "requests";

--- a/pkgs/stregsystemet/dependencies/six.nix
+++ b/pkgs/stregsystemet/dependencies/six.nix
@@ -1,4 +1,4 @@
-{pkgs ? import <nixpkgs> {}}:
+{pkgs}:
 
 pkgs.python3Packages.buildPythonPackage {
     pname = "six";

--- a/pkgs/stregsystemet/dependencies/sqlparse.nix
+++ b/pkgs/stregsystemet/dependencies/sqlparse.nix
@@ -1,4 +1,4 @@
-{pkgs ? import <nixpkgs> {}}:
+{pkgs}:
 
 pkgs.python3Packages.buildPythonPackage {
     pname = "sqlparse";

--- a/pkgs/stregsystemet/dependencies/urllib3.nix
+++ b/pkgs/stregsystemet/dependencies/urllib3.nix
@@ -1,4 +1,4 @@
-{pkgs ? import <nixpkgs> {}}:
+{pkgs}:
 
 pkgs.python3Packages.buildPythonPackage {
     pname = "urllib3";


### PR DESCRIPTION
Nix channels are unnecessary since we're accessing Nixpkgs as a flake. Avoiding them ensures that Stregsystemet and other potential packages always build with the same Nixpkgs version as the rest of the repo.